### PR TITLE
added additional whitespace validation for source urls

### DIFF
--- a/core-redirects-studio-lib/src/main/java/com/tallence/core/redirects/studio/model/RedirectUpdateProperties.java
+++ b/core-redirects-studio-lib/src/main/java/com/tallence/core/redirects/studio/model/RedirectUpdateProperties.java
@@ -44,6 +44,7 @@ public class RedirectUpdateProperties {
   static final String INVALID_ACTIVE_VALUE = "active_invalid";
   static final String INVALID_SOURCE_URL_TYPE_VALUE = "sourceUrlType_invalid";
   static final String INVALID_SOURCE_VALUE = "source_invalid";
+  static final String INVALID_SOURCE_WHITESPACE = "source_whitespace";
   static final String SOURCE_ALREADY_EXISTS = "source_already_exists";
   static final String INVALID_REDIRECT_TYPE_VALUE = "redirectType_invalid";
   static final String INVALID_DESCRIPTION_VALUE = "description_invalid";
@@ -142,6 +143,8 @@ public class RedirectUpdateProperties {
     if (StringUtils.isNotEmpty(source)) {
       if (!sourceIsValid(source)) {
         errors.put(SOURCE, INVALID_SOURCE_VALUE);
+      } else if (sourceHasWhitespaces(source)) {
+        errors.put(SOURCE, INVALID_SOURCE_WHITESPACE);
       } else if (StringUtils.isNotBlank(redirectId) && repository.sourceAlreadyExists(siteId, redirectId, source) ||
               StringUtils.isBlank(redirectId) && repository.sourceAlreadyExists(siteId, source)) {
         errors.put(SOURCE, SOURCE_ALREADY_EXISTS);
@@ -176,6 +179,10 @@ public class RedirectUpdateProperties {
 
   private static boolean sourceIsValid(String source) {
     return StringUtils.isNotEmpty(source) && source.startsWith("/") && source.length() < 512;
+  }
+
+  private static boolean sourceHasWhitespaces(String source) {
+    return StringUtils.isNotEmpty(source) && !source.matches("\\S+"); //only non-whitespace characters
   }
 
 }

--- a/core-redirects-studio-lib/src/test/java/com/tallence/core/redirects/studio/model/RedirectUpdatePropertiesTest.java
+++ b/core-redirects-studio-lib/src/test/java/com/tallence/core/redirects/studio/model/RedirectUpdatePropertiesTest.java
@@ -93,6 +93,19 @@ public class RedirectUpdatePropertiesTest {
   }
 
   @Test
+  public void testUpdateValidationWhitespacesSource() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(SOURCE, "/url-with-whitespaces  ");
+
+    RedirectUpdateProperties updateProperties = new RedirectUpdateProperties(properties, repository, null, "123");
+
+    Map<String, String> errors = updateProperties.validate();
+    assertThat(errors.get(SOURCE), equalTo(INVALID_SOURCE_WHITESPACE));
+
+  }
+
+
+  @Test
   public void testCreateValidationInvalidTargetLink() {
 
     Content targetLink = mock(Content.class);

--- a/core-redirects-studio-plugin/src/main/joo/com/tallence/core/redirects/studio/bundles/RedirectManagerStudioPlugin.properties
+++ b/core-redirects-studio-plugin/src/main/joo/com/tallence/core/redirects/studio/bundles/RedirectManagerStudioPlugin.properties
@@ -102,6 +102,7 @@ redirectmanager_editor_actions_csvupload_import_error_length_invalid=Invalid len
 redirectmanager_editor_actions_csvupload_import_error_active_invalid=The value for 'active' may only be true or false.
 redirectmanager_editor_actions_csvupload_import_error_sourceUrlType_invalid=The value for'sourceUrlType' should be'REGEX' or'PLAIN'.
 redirectmanager_editor_actions_csvupload_import_error_source_invalid=The value for the source must not be empty and must start with '/'.
+redirectmanager_editor_actions_csvupload_import_error_source_whitespace=The value for the source must not contain whitespace characters.
 redirectmanager_editor_actions_csvupload_import_error_source_already_exists=There is already a redirect for that source url.
 redirectmanager_editor_actions_csvupload_import_error_target_missing=The redirect must contain a target.
 redirectmanager_editor_actions_csvupload_import_error_target_invalid=To publish the redirect the target must be published.
@@ -111,6 +112,7 @@ redirectmanager_editor_actions_csvupload_import_error_description_invalid=The de
 redirectmanager_editor_actions_csvupload_import_error_duplicate_source=The import contains this source multiple times.
 
 redirectmanager_editor_error_source_invalid=The value for the source must not be empty and must start with '/'.
+redirectmanager_editor_error_source_whitespace=The value for the source must not contain whitespace characters.
 redirectmanager_editor_error_source_already_exists=There is already a redirect for that source url.
 redirectmanager_editor_error_target_missing=The redirect must contain a target.
 redirectmanager_editor_error_target_invalid=To publish the redirect the target must be published.

--- a/core-redirects-studio-plugin/src/main/joo/com/tallence/core/redirects/studio/bundles/RedirectManagerStudioPlugin_de.properties
+++ b/core-redirects-studio-plugin/src/main/joo/com/tallence/core/redirects/studio/bundles/RedirectManagerStudioPlugin_de.properties
@@ -84,6 +84,7 @@ redirectmanager_editor_actions_csvupload_import_error_length_invalid=Es werden 6
 redirectmanager_editor_actions_csvupload_import_error_active_invalid=Der Wert f\u00FCr 'active' darf nur true oder false sein.
 redirectmanager_editor_actions_csvupload_import_error_sourceUrlType_invalid=Der Wert f\u00FCr 'sourceUrlType' darf entweder 'REGEX' oder 'PLAIN' sein.
 redirectmanager_editor_actions_csvupload_import_error_source_invalid=Der Wert f\u00FCr die Quelle darf nicht leer sein und muss mit einem '/' beginnen.
+redirectmanager_editor_actions_csvupload_import_error_source_whitespace=Der Wert f\u00FCr die Quelle darf keine Leerzeichen enthalten.
 redirectmanager_editor_actions_csvupload_import_error_source_already_exists=Es existiert bereits eine Umleitung f\u00FCr die Quelle.
 redirectmanager_editor_actions_csvupload_import_error_target_missing=Die Umleitung ben\u00F6tigt ein Ziel.
 redirectmanager_editor_actions_csvupload_import_error_target_invalid=Um die Umleitung publizieren zu k\u00F6nnen muss das Ziel publiziert sein.
@@ -93,6 +94,7 @@ redirectmanager_editor_actions_csvupload_import_error_description_invalid=Die Be
 redirectmanager_editor_actions_csvupload_import_error_duplicate_source=Der Csv-Import enth\u00E4lt die Quell-Url mehrmals.
 
 redirectmanager_editor_error_source_invalid=Der Wert f\u00FCr die Quelle darf nicht leer sein und muss mit einem '/' beginnen.
+redirectmanager_editor_error_source_whitespace=Der Wert f\u00FCr die Quelle darf keine Leerzeichen enthalten.
 redirectmanager_editor_error_source_already_exists=Es existiert bereits eine Umleitung f\u00FCr die Quelle.
 redirectmanager_editor_error_target_missing=Die Umleitung ben\u00F6tigt ein Ziel.
 redirectmanager_editor_error_target_invalid=Um die Umleitung publizieren zu k\u00F6nnen muss das Ziel publiziert sein.
@@ -106,7 +108,7 @@ redirectmanager_editor_grid_redirect_delete_label=Umleitung l\u00F6schen
 redirectmanager_editor_grid_redirect_open_label=Umleitungsziel \u00F6ffnen
 
 redirectmanager_decision_use404Type=Eine Quelle, die mit einer ID endet kann im Zusammenhang mit dem ${redirectmanager_editor_field_type} "${redirectmanager_editor_field_type_value_1}" dazu f\u00FChren, dass der Redirect nicht korrekt funktioniert. Der Typ sollte auf "${redirectmanager_editor_field_type_value_0}" ge\u00E4ndert werden.
-redirectmanager_decision_useAlwaysType=Der ${redirectmanager_editor_field_type} "${redirectmanager_editor_field_type_value_0}" sollte nur in Ausnahmef\u00E4llen verwendet werden. Ansonsten k\u00F6nnten Anfragen auf g\u00FCltige Seiten durch alte Umleitungen versehentlich umgeleitet werden. Der Typ sollte auf "${redirectmanager_editor_field_type_value_1}" ge\u00E4ndert werden. 
+redirectmanager_decision_useAlwaysType=Der ${redirectmanager_editor_field_type} "${redirectmanager_editor_field_type_value_0}" sollte nur in Ausnahmef\u00E4llen verwendet werden. Ansonsten k\u00F6nnten Anfragen auf g\u00FCltige Seiten durch alte Umleitungen versehentlich umgeleitet werden. Der Typ sollte auf "${redirectmanager_editor_field_type_value_1}" ge\u00E4ndert werden.
 redirectmanager_decision_ok=${redirectmanager_editor_field_type} \u00E4ndern und speichern
 redirectmanager_decision_title=\u00DCberpr\u00FCfung des ${redirectmanager_editor_field_type}
 


### PR DESCRIPTION
Leerzeichen (z.B. am Ende der Source-URL) werden nicht abgefangen, Redirects funktionieren dann nicht.
Zusätzlicher Validator hinzugefügt. Als separate Überprüfung, um die Validierungsbotschaften nicht zu überfüllen.