### PR TITLE
The RedirectFilter compares the decoded pathInfo from a request with …

### DIFF
--- a/core-redirects-cae/src/main/java/com/tallence/core/redirects/cae/service/SiteRedirects.java
+++ b/core-redirects-cae/src/main/java/com/tallence/core/redirects/cae/service/SiteRedirects.java
@@ -15,16 +15,20 @@
  */
 package com.tallence.core.redirects.cae.service;
 
+import com.tallence.core.redirects.cae.filter.RedirectFilter;
 import com.tallence.core.redirects.cae.model.Redirect;
 import com.tallence.core.redirects.model.SourceUrlType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Holder class for the redirects of a specific site.
@@ -63,12 +67,16 @@ public class SiteRedirects {
 
   /**
    * Adds the given redirect to the cache, if it is valid.
+   *
+   * The url will be decoded because {@link javax.servlet.http.HttpServletRequest#getPathInfo} will
+   * return a decoded pathInfo too. The decoding must not handle params, schemes, ports etc. because the lookup
+   * in the {@link RedirectFilter} matches the source with the Request-PathInfo only
    */
   public void addRedirect(Redirect redirect) {
     if (redirect.getSourceUrlType() == SourceUrlType.PLAIN) {
       synchronized (plainRedirectsMonitor) {
         plainRedirects.values().remove(redirect);
-        plainRedirects.put(redirect.getSource(), redirect);
+        plainRedirects.put(URLDecoder.decode(redirect.getSource(), UTF_8), redirect);
       }
 
     } else if (redirect.getSourceUrlType() == SourceUrlType.REGEX) {

--- a/core-redirects-cae/src/test/java/com/tallence/core/redirects/cae/filter/RedirectFilterTest.java
+++ b/core-redirects-cae/src/test/java/com/tallence/core/redirects/cae/filter/RedirectFilterTest.java
@@ -125,7 +125,13 @@ public class RedirectFilterTest extends AbstractRedirectsTest {
   @Test
   public void testKeepParamsWithSpecialChar() throws Exception {
     MockServletContext servletContext = new MockServletContext();
-    HttpServletRequest request = requestTestHelper.createRequest("/channela/redirect-special-char").param("param1", "testVálüe1").buildRequest(servletContext);
+    //Workaround to use a special char in the path (as in a running CAE):
+    // set the pathInfo in an already created MockHttpServletRequestBuilder to avoid decoding with ISO-8859-1.
+    HttpServletRequest request = requestTestHelper
+            .createRequest("/")
+            .pathInfo("/channela/redirect-speciél-char")
+            .param("param1", "testVálüe1")
+            .buildRequest(servletContext);
     HttpServletResponse response = new MockHttpServletResponse();
     FilterChain filterChain = new MockFilterChain(getOkServlet());
 

--- a/core-redirects-cae/src/test/resources/com/tallence/core/redirects/cae/testdata/content.xml
+++ b/core-redirects-cae/src/test/resources/com/tallence/core/redirects/cae/testdata/content.xml
@@ -100,7 +100,7 @@
               <document id="1115114" name="TestRedirectSpecialChar" type="Redirect">
                 <version number="1">
                   <stringProperty name="sourceUrlType" value="PLAIN"/>
-                  <stringProperty name="source" value="/redirect-special-char"/>
+                  <stringProperty name="source" value="/redirect-speci%C3%A9l-char"/>
                   <linkProperty name="targetLink" Max="1" LinkType="CMLinkable">
                     <link id="10026"/>
                   </linkProperty>


### PR DESCRIPTION
…the Redirects source-property in the plainRedirects-Map. The pathInfo is decoded, the source-property in the plainRedirects-Map (now) too.